### PR TITLE
macos dmg for x86 and arm64 via github action

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -355,9 +355,10 @@ jobs:
             "-DOpenMP_C_LIB_NAMES=omp"
             "-DOpenMP_C_LIBRARY=${LIBOMP}/lib/libomp.dylib"
             "-DCMAKE_PREFIX_PATH=${QT_ROOT_DIR}"
-            # Blaze3D doubles DMG size (second full Qt+GDAL bundle via
-            # macdeployqt). Omit from macOS releases until we share frameworks.
-            "-DBLAZE_BUILD_3D_GUI=OFF"
+            # Blaze3D is included. It costs ~2x DMG size because macdeployqt
+            # bundles a second full copy of the Qt+GDAL stack into Blaze3D.app
+            # (the two apps don't yet share frameworks).
+            "-DBLAZE_BUILD_3D_GUI=ON"
           )
           if [ -n "${{ steps.version.outputs.version }}" ]; then
             CMAKE_ARGS+=("-DBLAZE_VERSION=${{ steps.version.outputs.version }}")
@@ -374,11 +375,11 @@ jobs:
           # No -libpath gymnastics needed: official Qt has all modules
           # under a single prefix and uses standard @rpath references that
           # macdeployqt resolves natively.
-          if [ -d "staging/Blaze.app" ]; then
-            macdeployqt "staging/Blaze.app" -always-overwrite
-          fi
+          for app in staging/Blaze.app staging/Blaze3D.app; do
+            [ -d "$app" ] && macdeployqt "$app" -always-overwrite
+          done
 
-          # Sanity check that every Qt framework Blaze links got bundled.
+          # Sanity check that every Qt framework each app links got bundled.
           verify_frameworks() {
             local app="$1"; shift
             local fw_dir="staging/$app.app/Contents/Frameworks"
@@ -394,30 +395,37 @@ jobs:
             echo "$app.app: all required Qt frameworks present"
           }
 
-          if [ -d "staging/Blaze.app" ]; then
-            verify_frameworks Blaze QtCore QtGui QtWidgets QtConcurrent
-          fi
-      - name: Bundle libomp
-        run: |
-          LIBOMP=$(brew --prefix libomp)/lib/libomp.dylib
-          MACDIR="staging/Blaze.app/Contents/MacOS"
-          if [ -f "$MACDIR/Blaze" ] && [ ! -f "$MACDIR/libomp.dylib" ]; then
-            cp "$LIBOMP" "$MACDIR/"
-            install_name_tool -change "$LIBOMP" "@executable_path/libomp.dylib" "$MACDIR/Blaze"
-          fi
+          [ -d staging/Blaze.app ]   && verify_frameworks Blaze   QtCore QtGui QtWidgets QtConcurrent
+          [ -d staging/Blaze3D.app ] && verify_frameworks Blaze3D QtCore QtGui QtWidgets QtConcurrent
       - name: Bundle missing transitive libraries
         run: |
-          # macdeployqt leaves out transitive dependencies of the Homebrew GDAL
-          # stack (e.g. GDAL -> libgeos_c -> libgeos, jpeg-xl, the AWS SDK)
-          # because those dylibs carry a "@loader_path/../lib" rpath that breaks
-          # once relocated into Contents/Frameworks. Without this the .dmg
-          # crashes on a clean Mac with "Library not loaded: @rpath/libgeos...".
-          # This walks the dependency closure, pulls in whatever is missing,
-          # normalizes install names and re-signs (mandatory on Apple Silicon).
+          # macdeployqt leaves out (a) transitive dependencies of the Homebrew
+          # GDAL stack (GDAL -> libgeos_c -> libgeos, jpeg-xl, the AWS SDK),
+          # whose "@loader_path/../lib" rpath breaks once relocated into
+          # Contents/Frameworks, and (b) libraries the executable links directly
+          # such as libomp. Without this the .dmg crashes on a clean Mac with
+          # "Library not loaded: @rpath/libgeos...". The script walks the
+          # dependency closure from the executables AND frameworks, pulls in
+          # whatever is missing, normalizes install names, and re-signs every
+          # binary it touched — including the Qt frameworks, without which the
+          # invalidated code seal makes Gatekeeper report the app as "damaged".
           chmod +x scripts/macos-fix-deps.sh
-          if [ -d "staging/Blaze.app" ]; then
-            scripts/macos-fix-deps.sh "staging/Blaze.app"
-          fi
+          for app in staging/Blaze.app staging/Blaze3D.app; do
+            [ -d "$app/Contents/Frameworks" ] && scripts/macos-fix-deps.sh "$app"
+          done
+      - name: Verify bundles are self-contained + validly signed
+        run: |
+          # Hard gate: fail the build if any bundle still references a host-only
+          # library (Homebrew/Qt/Cellar) or has an invalid code signature — i.e.
+          # anything that would crash or show "damaged" on a clean Mac. The CI
+          # runner HAS Qt/GDAL/Homebrew, so without this check a half-bundled app
+          # can pass the blaze-cli smoke test yet be broken for end users.
+          chmod +x scripts/macos-verify-bundle.sh
+          apps=()
+          for app in staging/Blaze.app staging/Blaze3D.app; do
+            [ -d "$app/Contents/Frameworks" ] && apps+=("$app")
+          done
+          scripts/macos-verify-bundle.sh "${apps[@]}"
       - name: Package (DMG)
         run: |
           if [ -n "${{ steps.version.outputs.version }}" ]; then

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -447,7 +447,27 @@ jobs:
           fi
           ARCH=$(uname -m)
           DMG="build/Blaze-${VERSION}-macOS-${ARCH}.dmg"
-          hdiutil create -volname "Blaze" -srcfolder staging -ov -format UDZO "$DMG"
+
+          # hdiutil create intermittently fails with "Resource busy" on the
+          # macOS runners (Spotlight/mds is still indexing the freshly written
+          # staging tree — more so now that we copy the asset tree into each
+          # .app). Flush pending writes, detach any stale Blaze volume, and
+          # retry with backoff so a transient lock doesn't fail the release.
+          sync
+          hdiutil detach /Volumes/Blaze -force 2>/dev/null || true
+          created=false
+          for i in 1 2 3 4 5; do
+            if hdiutil create -volname "Blaze" -srcfolder staging -ov -format UDZO "$DMG"; then
+              created=true
+              break
+            fi
+            echo "hdiutil create failed (attempt $i), retrying in 10s..."
+            sleep 10
+          done
+          if [ "$created" != true ]; then
+            echo "Failed to create DMG after 5 attempts"
+            exit 1
+          fi
           echo "DMG: $DMG"
       - name: Test installer
         run: |

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -405,6 +405,19 @@ jobs:
             cp "$LIBOMP" "$MACDIR/"
             install_name_tool -change "$LIBOMP" "@executable_path/libomp.dylib" "$MACDIR/Blaze"
           fi
+      - name: Bundle missing transitive libraries
+        run: |
+          # macdeployqt leaves out transitive dependencies of the Homebrew GDAL
+          # stack (e.g. GDAL -> libgeos_c -> libgeos, jpeg-xl, the AWS SDK)
+          # because those dylibs carry a "@loader_path/../lib" rpath that breaks
+          # once relocated into Contents/Frameworks. Without this the .dmg
+          # crashes on a clean Mac with "Library not loaded: @rpath/libgeos...".
+          # This walks the dependency closure, pulls in whatever is missing,
+          # normalizes install names and re-signs (mandatory on Apple Silicon).
+          chmod +x scripts/macos-fix-deps.sh
+          if [ -d "staging/Blaze.app" ]; then
+            scripts/macos-fix-deps.sh "staging/Blaze.app"
+          fi
       - name: Package (DMG)
         run: |
           if [ -n "${{ steps.version.outputs.version }}" ]; then

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -368,6 +368,18 @@ jobs:
         run: cmake --build build --config Release --parallel
       - name: Stage install
         run: cmake --install build --prefix staging --config Release
+      - name: Bundle assets inside .app bundles
+        run: |
+          # Make each GUI app self-contained by copying assets into the bundle.
+          # Without this the downloaded, quarantined .app crashes on launch under
+          # Gatekeeper App Translocation (runs from a random temp dir with no
+          # sibling share/assets). See scripts/macos-bundle-assets.sh header.
+          chmod +x scripts/macos-bundle-assets.sh
+          apps=()
+          for app in staging/Blaze.app staging/Blaze3D.app; do
+            [ -d "$app" ] && apps+=("$app")
+          done
+          scripts/macos-bundle-assets.sh staging/share/assets "${apps[@]}"
       - name: Deploy Qt frameworks
         run: |
           # macdeployqt comes from the official Qt distribution (installed

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ blaze-cli
 compile_commands.json
 
 build
+macos-build
 linux-build
 .clangd
 

--- a/scripts/macos-build.sh
+++ b/scripts/macos-build.sh
@@ -5,7 +5,10 @@ DIR="macos-build"
 
 # Resolve Homebrew prefixes; fall back gracefully if a formula is missing.
 LIBOMP_PREFIX=$(brew --prefix libomp 2>/dev/null || true)
-QT_PREFIX=$(brew --prefix qt@6 2>/dev/null || brew --prefix qt6 2>/dev/null || true)
+# Homebrew splits Qt6 across many kegs. Try the split-package keg first
+# (qtbase has Qt6Config.cmake); fall back to the monolithic qt@6/qt6 alias
+# for older Homebrew setups where Qt ships as a single formula.
+QT_PREFIX=$(brew --prefix qtbase 2>/dev/null || brew --prefix qt@6 2>/dev/null || brew --prefix qt6 2>/dev/null || true)
 
 CMAKE_EXTRA=()
 

--- a/scripts/macos-build.sh
+++ b/scripts/macos-build.sh
@@ -39,6 +39,24 @@ cmake --build "$DIR" --parallel "$(sysctl -n hw.logicalcpu)"
 
 cp "$DIR/blaze-cli" .
 if [ -d "$DIR/Blaze.app" ]; then
+    # Remove first in case a previous copy came from a read-only source (e.g. a
+    # mounted DMG), which leaves files with 444 permissions that cp can't overwrite.
+    rm -rf ./Blaze.app ./Blaze3D.app
     cp -r "$DIR/Blaze.app" .
     cp -r "$DIR/Blaze3D.app" .
+fi
+
+# Write qt.conf into each development-build .app so Qt can find its platform
+# plugin (libqcocoa.dylib) without needing QT_PLUGIN_PATH in the environment.
+# Homebrew's split-package Qt puts plugins in a non-standard per-keg path that
+# Qt's compiled-in default search doesn't discover automatically; qt.conf
+# overrides the search path for this local build only.
+if [ -n "$QT_PREFIX" ]; then
+    QT_PLUGINS="$QT_PREFIX/share/qt/plugins"
+    [ -d "$QT_PLUGINS" ] || QT_PLUGINS="$QT_PREFIX/plugins"
+
+    for APP in "$DIR/Blaze.app" "$DIR/Blaze3D.app" ./Blaze.app ./Blaze3D.app; do
+        [ -d "$APP/Contents/MacOS" ] || continue
+        printf '[Paths]\nPlugins = %s\n' "$QT_PLUGINS" > "$APP/Contents/MacOS/qt.conf"
+    done
 fi

--- a/scripts/macos-bundle-assets.sh
+++ b/scripts/macos-bundle-assets.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copy the runtime assets INTO each macOS .app bundle so the app is fully
+# self-contained.
+#
+# Why this is needed:
+#   On Linux/Windows the assets ship beside the binary in <prefix>/share/assets,
+#   and get_asset_dir() finds them relative to the executable. On macOS that
+#   sibling layout breaks under Gatekeeper "App Translocation": when a user
+#   downloads the DMG and launches a (quarantined, un-notarized) .app, macOS
+#   copies the .app ALONE into a random read-only temp dir and runs it from
+#   there — with no sibling share/ directory. get_asset_dir() then finds none of
+#   its candidate paths and throws, so the GUI aborts immediately on launch.
+#
+#   get_asset_dir() already checks <App>.app/Contents/share/assets FIRST (it is
+#   the executable-relative "../share/assets" candidate), and that path lives
+#   inside the bundle, so it survives translocation. Populating it makes the app
+#   self-contained with no source change. The CLI keeps using the external
+#   share/assets (it is not an .app and is never translocated).
+#
+# Usage: scripts/macos-bundle-assets.sh <assets-src-dir> <App.app> [App2.app ...]
+
+set -u
+
+ASSETS_SRC="${1:-}"
+shift || true
+
+if [ -z "$ASSETS_SRC" ] || [ ! -d "$ASSETS_SRC" ]; then
+    echo "ERROR: assets source dir not found: '$ASSETS_SRC'" >&2
+    exit 1
+fi
+[ "$#" -ge 1 ] || { echo "usage: $0 <assets-src-dir> App.app [App2.app ...]" >&2; exit 2; }
+
+for app in "$@"; do
+    [ -d "$app" ] || continue
+    dest="$app/Contents/share/assets"
+    rm -rf "$dest"
+    mkdir -p "$app/Contents/share"
+    cp -R "$ASSETS_SRC" "$dest"
+    echo "    $(basename "$app"): bundled assets -> Contents/share/assets"
+done

--- a/scripts/macos-fix-deps.sh
+++ b/scripts/macos-fix-deps.sh
@@ -15,10 +15,13 @@
 #   have the same shape).
 #
 # What it does, for each .app passed as an argument:
-#   1. Closure: repeatedly scan Contents/Frameworks for @rpath/ or Homebrew
-#      absolute dependencies that aren't present yet, locate them on the host
-#      (via the Homebrew prefix, so no version numbers are hardcoded) and copy
-#      them in, until nothing is missing. Once a library physically sits in
+#   1. Closure: repeatedly scan the bundle's Mach-O files — the executables in
+#      Contents/MacOS, the plugins, and everything in Contents/Frameworks — for
+#      @rpath/ or Homebrew absolute dependencies that aren't present yet, locate
+#      them on the host (via the Homebrew prefix, so no version numbers are
+#      hardcoded) and copy them in, until nothing is missing. Seeding from the
+#      executables (not just Frameworks) is what bundles libraries the binary
+#      links directly, e.g. libomp. Once a library physically sits in
 #      Contents/Frameworks, the app executable's own
 #      "@executable_path/../Frameworks" rpath resolves the @rpath reference, so
 #      the broken per-library rpath does not need rewriting.
@@ -68,14 +71,30 @@ find_host_lib() {
     return 1
 }
 
+# All Mach-O files to walk as roots of the dependency closure: everything
+# already in Frameworks, the app's main executables, and bundled plugins.
+# Seeding from the executables (not just Frameworks) is what pulls in libraries
+# the binary links DIRECTLY — e.g. libomp from OpenMP — so they get bundled,
+# id-normalized and signed by this one code path instead of a bespoke step.
+closure_roots() {
+    local app="$1"
+    ls "$app"/Contents/Frameworks/*.dylib 2>/dev/null
+    find "$app/Contents/MacOS" -type f 2>/dev/null
+    find "$app/Contents/PlugIns" -name '*.dylib' 2>/dev/null
+}
+
 # Phase 1: copy missing dependencies into Frameworks until the graph is closed.
 copy_missing() {
-    local fw="$1" progressed=1 round=0 lib dep depbase src deps
+    local app="$1" fw="$app/Contents/Frameworks"
+    local progressed=1 round=0 lib dep depbase src deps roots
     while [ "$progressed" -eq 1 ] && [ "$round" -lt 25 ]; do
         progressed=0
         round=$((round + 1))
-        for lib in "$fw"/*.dylib; do
+        roots="$(closure_roots "$app")"
+        while IFS= read -r lib; do
             [ -e "$lib" ] || continue
+            # Skip non-Mach-O entries (e.g. shell scripts that live in MacOS/).
+            case "$(file -b "$lib" 2>/dev/null)" in *Mach-O*) ;; *) continue ;; esac
             deps="$(deps_of "$lib")" # consume the pipe fully, THEN iterate
             while IFS= read -r dep; do
                 [ -n "$dep" ] || continue
@@ -103,7 +122,9 @@ copy_missing() {
             done <<EOF
 $deps
 EOF
-        done
+        done <<ROOTS
+$roots
+ROOTS
     done
 }
 
@@ -131,12 +152,50 @@ $deps
 EOF
 }
 
+# Frameworks need their own pass: a framework's load name is the multi-segment
+# path Foo.framework/Versions/A/Foo, not a leaf Foo.dylib, so normalize_one's
+# basename logic can't id them. Homebrew/Qt leave some framework binaries with
+# an absolute self-id (e.g. /usr/local/opt/qtbase/lib/QtDBus.framework/.../QtDBus)
+# and absolute references to sibling frameworks; rewrite both to the bundle's
+# @rpath/<relative-path> so they resolve on a machine without Qt installed.
+normalize_frameworks() {
+    local app="$1" fw="$app/Contents/Frameworks" binfile relpath dep drel deps bins
+    # Real versioned binaries only (-type f skips the Current/leaf symlinks).
+    bins="$(find "$fw" -type f -path '*.framework/Versions/*' 2>/dev/null)"
+    while IFS= read -r binfile; do
+        [ -n "$binfile" ] || continue
+        case "$(file -b "$binfile" 2>/dev/null)" in *Mach-O*) ;; *) continue ;; esac
+        chmod u+w "$binfile" 2>/dev/null
+        relpath="${binfile#"$fw"/}"
+        install_name_tool -id "@rpath/$relpath" "$binfile" 2>/dev/null
+        deps="$(deps_of "$binfile")"
+        while IFS= read -r dep; do
+            case "$dep" in
+                "$BREW_PREFIX"/*.framework/*|/usr/local/*.framework/*)
+                    # .../lib/QtCore.framework/Versions/A/QtCore -> QtCore.framework/Versions/A/QtCore
+                    drel="$(printf '%s\n' "$dep" | sed -E 's#^.*/([^/]+\.framework/)#\1#')"
+                    [ -e "$fw/$drel" ] && install_name_tool -change "$dep" "@rpath/$drel" "$binfile" 2>/dev/null
+                    ;;
+                "$BREW_PREFIX"/*.dylib|/usr/local/*.dylib)
+                    drel="$(basename "$dep")"
+                    [ -f "$fw/$drel" ] && install_name_tool -change "$dep" "@rpath/$drel" "$binfile" 2>/dev/null
+                    ;;
+            esac
+        done <<EOF
+$deps
+EOF
+    done <<FWBINS
+$bins
+FWBINS
+}
+
 normalize() {
     local app="$1" fw="$app/Contents/Frameworks" lib exe
     for lib in "$fw"/*.dylib; do
         [ -e "$lib" ] || continue
         normalize_one "$lib" "$fw" id
     done
+    normalize_frameworks "$app"
     for exe in "$app/Contents/MacOS/"*; do
         [ -f "$exe" ] || continue
         case "$(file -b "$exe" 2>/dev/null)" in *Mach-O*) ;; *) continue ;; esac
@@ -144,19 +203,57 @@ normalize() {
     done
 }
 
-# Phase 3: ad-hoc re-sign everything install_name_tool touched.
+# Phase 3: ad-hoc re-sign everything, inside-out.
+#
+# Order matters: codesign seals a container over its current contents, so every
+# nested item must be signed BEFORE the thing that contains it, and the .app
+# itself signed last. The critical, easy-to-miss case is frameworks: a
+# framework's binary is Contents/Frameworks/QtGui.framework/Versions/A/QtGui —
+# it has NO .dylib extension, so the *.dylib sweep skips it. The official Qt
+# frameworks ship with a Developer-ID + hardened-runtime signature; the
+# install_name_tool edits above invalidate it, and if we never re-sign the
+# framework the whole app seal is invalid and Gatekeeper reports the downloaded
+# app as "damaged and can't be opened". So we explicitly sign each framework.
 resign() {
-    local app="$1" f exe
+    local app="$1" f exe fw
+    # 1. Every dylib anywhere (loose libs, plugins, any nested inside frameworks)
+    #    so the containers below seal over already-valid contents.
     while IFS= read -r f; do
         [ -n "$f" ] && codesign --force --sign - "$f" 2>/dev/null
     done <<EOF
 $(find "$app" -name '*.dylib')
 EOF
+    # 2. Each nested framework (signs its versioned binary + seals its resources).
+    for fw in "$app"/Contents/Frameworks/*.framework; do
+        [ -d "$fw" ] && codesign --force --sign - "$fw" 2>/dev/null
+    done
+    # 3. Main executables.
     for exe in "$app/Contents/MacOS/"*; do
         [ -f "$exe" ] || continue
         case "$(file -b "$exe" 2>/dev/null)" in *Mach-O*) codesign --force --sign - "$exe" 2>/dev/null ;; esac
     done
+    # 4. The app bundle last.
     codesign --force --sign - "$app" 2>/dev/null
+}
+
+# Phase 0: drop plugins Blaze does not use whose own (heavy) framework
+# dependencies macdeployqt fails to bundle. The virtual-keyboard input method
+# (platforminputcontexts) drags in the QtQuick/QtVirtualKeyboard QML stack, and
+# the PDF image format (imageformats/libqpdf) needs QtPdf — neither is used by a
+# desktop GIS app, and bundling those frameworks just to satisfy an unused
+# plugin would bloat the DMG. Removing the plugin removes the dependency, so the
+# closure stays self-contained.
+prune_unused_plugins() {
+    local app="$1" p
+    for p in \
+        Contents/PlugIns/platforminputcontexts \
+        Contents/PlugIns/imageformats/libqpdf.dylib
+    do
+        if [ -e "$app/$p" ]; then
+            rm -rf "$app/$p"
+            echo "    - pruned ${p#Contents/PlugIns/}"
+        fi
+    done
 }
 
 # Phase 4: report any @rpath/*.dylib dependency still unresolved.
@@ -190,7 +287,8 @@ for app in "$@"; do
         continue
     fi
     echo "==> Fixing $app"
-    copy_missing "$app/Contents/Frameworks"
+    prune_unused_plugins "$app"
+    copy_missing "$app"
     normalize "$app"
     resign "$app"
     if verify "$app"; then

--- a/scripts/macos-fix-deps.sh
+++ b/scripts/macos-fix-deps.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Make a macOS .app bundle self-contained by pulling in the transitive dylib
+# dependencies that macdeployqt misses.
+#
+# Why this is needed:
+#   macdeployqt copies an app's direct dependencies into Contents/Frameworks
+#   and rewrites their install names, but it does NOT reliably follow the
+#   dependency graph through Homebrew libraries. Homebrew dylibs carry an
+#   LC_RPATH of "@loader_path/../lib"; once such a dylib is relocated into
+#   Contents/Frameworks that rpath points at a nonexistent Contents/lib, so
+#   macdeployqt can't resolve the next library down and silently leaves it out.
+#   The bundle then crashes on a clean Mac with e.g.
+#       Library not loaded: @rpath/libgeos.3.14.1.dylib
+#   (GDAL -> libgeos_c -> libgeos is the classic case; jpeg-xl and the AWS SDK
+#   have the same shape).
+#
+# What it does, for each .app passed as an argument:
+#   1. Closure: repeatedly scan Contents/Frameworks for @rpath/ or Homebrew
+#      absolute dependencies that aren't present yet, locate them on the host
+#      (via the Homebrew prefix, so no version numbers are hardcoded) and copy
+#      them in, until nothing is missing.
+#   2. Normalize: rewrite every bundled dylib's id to @rpath/<name>, repoint the
+#      broken "@loader_path/../lib" rpath at "@loader_path", and rewrite any
+#      remaining Homebrew-absolute dependency references (incl. OpenCV's
+#      hardcoded self-referential ids) to @rpath/<name>.
+#   3. Re-sign: ad-hoc codesign everything that was modified. Apple Silicon
+#      refuses to load dylibs whose signature install_name_tool invalidated, so
+#      this is mandatory for the arm64 build, and harmless on Intel.
+#   4. Verify: fail if any @rpath/*.dylib dependency is still unresolved.
+#
+# Usage: scripts/macos-fix-deps.sh path/to/Foo.app [path/to/Bar.app ...]
+
+set -euo pipefail
+
+BREW_PREFIX="$(brew --prefix 2>/dev/null || echo /usr/local)"
+
+# Directories to search for a library referenced only by basename (@rpath/X).
+SEARCH_DIRS=("$BREW_PREFIX/lib")
+for d in "$BREW_PREFIX"/opt/*/lib; do
+    [ -d "$d" ] && SEARCH_DIRS+=("$d")
+done
+
+# Print a dylib/executable's dependency install names (skip the header line;
+# the id line of a dylib is harmless here and filtered downstream).
+deps_of() { otool -L "$1" 2>/dev/null | tail -n +2 | awk '{print $1}'; }
+
+# Locate a library by basename on the host. Echoes the path, or returns 1.
+find_host_lib() {
+    local name="$1" d
+    for d in "${SEARCH_DIRS[@]}"; do
+        [ -f "$d/$name" ] && { printf '%s\n' "$d/$name"; return 0; }
+    done
+    return 1
+}
+
+# Phase 1: copy missing dependencies into Frameworks until the graph is closed.
+copy_missing() {
+    local fw="$1"
+    local progressed=1 round=0 lib dep depbase src
+    while [ "$progressed" -eq 1 ]; do
+        progressed=0
+        round=$((round + 1))
+        for lib in "$fw"/*.dylib; do
+            [ -e "$lib" ] || continue
+            while IFS= read -r dep; do
+                case "$dep" in
+                    @rpath/*.dylib) depbase="${dep#@rpath/}" ;;
+                    "$BREW_PREFIX"/*.dylib | /usr/local/*.dylib) depbase="$(basename "$dep")" ;;
+                    *) continue ;;
+                esac
+                [ -f "$fw/$depbase" ] && continue
+                if [ "${dep:0:1}" = "/" ] && [ -f "$dep" ]; then
+                    src="$dep"
+                else
+                    src="$(find_host_lib "$depbase" || true)"
+                fi
+                if [ -n "${src:-}" ] && [ -f "$src" ]; then
+                    cp "$src" "$fw/$depbase"
+                    chmod u+w "$fw/$depbase"
+                    echo "    + bundled $depbase"
+                    progressed=1
+                else
+                    echo "    ! could not locate $depbase (needed by $(basename "$lib"))" >&2
+                fi
+            done < <(deps_of "$lib")
+        done
+        [ "$round" -gt 25 ] && break
+    done
+    return 0
+}
+
+# Phase 2: normalize install names / rpaths so every lookup resolves in-bundle.
+normalize() {
+    local app="$1"
+    local fw="$app/Contents/Frameworks"
+    local lib base dep db rp exe
+
+    for lib in "$fw"/*.dylib; do
+        [ -e "$lib" ] || continue
+        base="$(basename "$lib")"
+        chmod u+w "$lib"
+        install_name_tool -id "@rpath/$base" "$lib" 2>/dev/null || true
+        # Repoint the broken "@loader_path/../lib" rpath at the Frameworks dir
+        # the library now lives in.
+        while IFS= read -r rp; do
+            [ "$rp" = "@loader_path/../lib" ] &&
+                install_name_tool -rpath "@loader_path/../lib" "@loader_path" "$lib" 2>/dev/null || true
+        done < <(otool -l "$lib" | awk '/LC_RPATH/{f=1} f&&/ path /{print $2; f=0}')
+        # Repoint any Homebrew-absolute dependency that is now bundled.
+        while IFS= read -r dep; do
+            case "$dep" in
+                "$BREW_PREFIX"/*.dylib | /usr/local/*.dylib)
+                    db="$(basename "$dep")"
+                    [ -f "$fw/$db" ] &&
+                        install_name_tool -change "$dep" "@rpath/$db" "$lib" 2>/dev/null || true
+                    ;;
+            esac
+        done < <(deps_of "$lib")
+    done
+
+    # Fix the same Homebrew-absolute references in the Mach-O executables.
+    for exe in "$app/Contents/MacOS/"*; do
+        [ -f "$exe" ] || continue
+        case "$(file -b "$exe" 2>/dev/null)" in *Mach-O*) ;; *) continue ;; esac
+        while IFS= read -r dep; do
+            case "$dep" in
+                "$BREW_PREFIX"/*.dylib | /usr/local/*.dylib)
+                    db="$(basename "$dep")"
+                    [ -f "$fw/$db" ] &&
+                        install_name_tool -change "$dep" "@rpath/$db" "$exe" 2>/dev/null || true
+                    ;;
+            esac
+        done < <(deps_of "$exe")
+    done
+    return 0
+}
+
+# Phase 3: ad-hoc re-sign everything install_name_tool touched.
+resign() {
+    local app="$1"
+    find "$app" -name '*.dylib' -exec codesign --remove-signature {} + 2>/dev/null || true
+    find "$app" -name '*.dylib' -exec codesign --force --sign - {} + 2>/dev/null || true
+    local exe
+    for exe in "$app/Contents/MacOS/"*; do
+        [ -f "$exe" ] || continue
+        case "$(file -b "$exe" 2>/dev/null)" in *Mach-O*) ;; *) continue ;; esac
+        codesign --force --sign - "$exe" 2>/dev/null || true
+    done
+    codesign --force --sign - "$app" 2>/dev/null || true
+    return 0
+}
+
+# Phase 4: fail if any @rpath/*.dylib dependency is still unresolved.
+verify() {
+    local app="$1"
+    local fw="$app/Contents/Frameworks"
+    local missing=0 lib dep db
+    for lib in "$fw"/*.dylib "$app/Contents/MacOS/"*; do
+        [ -f "$lib" ] || continue
+        while IFS= read -r dep; do
+            case "$dep" in
+                @rpath/*.dylib)
+                    db="${dep#@rpath/}"
+                    [ -f "$fw/$db" ] || {
+                        echo "    MISSING: $db (needed by $(basename "$lib"))" >&2
+                        missing=1
+                    }
+                    ;;
+            esac
+        done < <(deps_of "$lib")
+    done
+    return $missing
+}
+
+main() {
+    [ "$#" -ge 1 ] || { echo "usage: $0 App.app [App2.app ...]" >&2; exit 2; }
+    for app in "$@"; do
+        if [ ! -d "$app/Contents/Frameworks" ]; then
+            echo "==> $app: no Contents/Frameworks, skipping"
+            continue
+        fi
+        echo "==> Fixing $app"
+        copy_missing "$app/Contents/Frameworks"
+        normalize "$app"
+        resign "$app"
+        if verify "$app"; then
+            echo "    OK: all @rpath dependencies resolve inside the bundle"
+        else
+            echo "    FAILED: unresolved dependencies remain in $app" >&2
+            exit 1
+        fi
+    done
+}
+
+main "$@"

--- a/scripts/macos-fix-deps.sh
+++ b/scripts/macos-fix-deps.sh
@@ -18,19 +18,29 @@
 #   1. Closure: repeatedly scan Contents/Frameworks for @rpath/ or Homebrew
 #      absolute dependencies that aren't present yet, locate them on the host
 #      (via the Homebrew prefix, so no version numbers are hardcoded) and copy
-#      them in, until nothing is missing.
-#   2. Normalize: rewrite every bundled dylib's id to @rpath/<name>, repoint the
-#      broken "@loader_path/../lib" rpath at "@loader_path", and rewrite any
-#      remaining Homebrew-absolute dependency references (incl. OpenCV's
+#      them in, until nothing is missing. Once a library physically sits in
+#      Contents/Frameworks, the app executable's own
+#      "@executable_path/../Frameworks" rpath resolves the @rpath reference, so
+#      the broken per-library rpath does not need rewriting.
+#   2. Normalize: rewrite every bundled dylib's id to @rpath/<name> and repoint
+#      any remaining Homebrew-absolute dependency references (including OpenCV's
 #      hardcoded self-referential ids) to @rpath/<name>.
 #   3. Re-sign: ad-hoc codesign everything that was modified. Apple Silicon
 #      refuses to load dylibs whose signature install_name_tool invalidated, so
 #      this is mandatory for the arm64 build, and harmless on Intel.
-#   4. Verify: fail if any @rpath/*.dylib dependency is still unresolved.
+#   4. Verify: exit non-zero if any @rpath/*.dylib dependency is still
+#      unresolved.
+#
+# Implementation note: this deliberately does NOT use `set -e`/`pipefail`, and
+# it reads each dependency list fully into a variable before iterating (rather
+# than piping a live `otool` into a loop that runs install_name_tool). A live
+# pipe feeding a loop that runs crash-prone tools, combined with `set -e`, can
+# tear the shell down mid-pipe and abort the whole script. Errors are handled
+# explicitly and the final verify determines success.
 #
 # Usage: scripts/macos-fix-deps.sh path/to/Foo.app [path/to/Bar.app ...]
 
-set -euo pipefail
+set -u
 
 BREW_PREFIX="$(brew --prefix 2>/dev/null || echo /usr/local)"
 
@@ -40,8 +50,7 @@ for d in "$BREW_PREFIX"/opt/*/lib; do
     [ -d "$d" ] && SEARCH_DIRS+=("$d")
 done
 
-# Print a dylib/executable's dependency install names (skip the header line;
-# the id line of a dylib is harmless here and filtered downstream).
+# Print a dylib/executable's dependency install names (skipping the header).
 deps_of() { otool -L "$1" 2>/dev/null | tail -n +2 | awk '{print $1}'; }
 
 # Locate a library by basename on the host. Echoes the path, or returns 1.
@@ -55,141 +64,134 @@ find_host_lib() {
 
 # Phase 1: copy missing dependencies into Frameworks until the graph is closed.
 copy_missing() {
-    local fw="$1"
-    local progressed=1 round=0 lib dep depbase src
-    while [ "$progressed" -eq 1 ]; do
+    local fw="$1" progressed=1 round=0 lib dep depbase src deps
+    while [ "$progressed" -eq 1 ] && [ "$round" -lt 25 ]; do
         progressed=0
         round=$((round + 1))
         for lib in "$fw"/*.dylib; do
             [ -e "$lib" ] || continue
+            deps="$(deps_of "$lib")" # consume the pipe fully, THEN iterate
             while IFS= read -r dep; do
+                [ -n "$dep" ] || continue
                 case "$dep" in
                     @rpath/*.dylib) depbase="${dep#@rpath/}" ;;
                     "$BREW_PREFIX"/*.dylib | /usr/local/*.dylib) depbase="$(basename "$dep")" ;;
                     *) continue ;;
                 esac
                 [ -f "$fw/$depbase" ] && continue
+                src=""
                 if [ "${dep:0:1}" = "/" ] && [ -f "$dep" ]; then
                     src="$dep"
                 else
-                    src="$(find_host_lib "$depbase" || true)"
+                    src="$(find_host_lib "$depbase" 2>/dev/null || true)"
                 fi
-                if [ -n "${src:-}" ] && [ -f "$src" ]; then
-                    cp "$src" "$fw/$depbase"
-                    chmod u+w "$fw/$depbase"
-                    echo "    + bundled $depbase"
-                    progressed=1
+                if [ -n "$src" ] && [ -f "$src" ]; then
+                    if cp "$src" "$fw/$depbase"; then
+                        chmod u+w "$fw/$depbase" 2>/dev/null
+                        echo "    + bundled $depbase"
+                        progressed=1
+                    fi
                 else
                     echo "    ! could not locate $depbase (needed by $(basename "$lib"))" >&2
                 fi
-            done < <(deps_of "$lib")
+            done <<EOF
+$deps
+EOF
         done
-        [ "$round" -gt 25 ] && break
     done
-    return 0
 }
 
-# Phase 2: normalize install names / rpaths so every lookup resolves in-bundle.
-normalize() {
-    local app="$1"
-    local fw="$app/Contents/Frameworks"
-    local lib base dep db rp exe
+# Phase 2: normalize install names so every lookup resolves in-bundle.
+normalize_one() {
+    # $1 = mach-o file, $2 = Frameworks dir, $3 = "id" to also set the id
+    local f="$1" fw="$2" setid="${3:-}" dep db deps
+    chmod u+w "$f" 2>/dev/null
+    if [ "$setid" = "id" ]; then
+        install_name_tool -id "@rpath/$(basename "$f")" "$f" 2>/dev/null
+    fi
+    deps="$(deps_of "$f")"
+    while IFS= read -r dep; do
+        [ -n "$dep" ] || continue
+        case "$dep" in
+            "$BREW_PREFIX"/*.dylib | /usr/local/*.dylib)
+                db="$(basename "$dep")"
+                if [ -f "$fw/$db" ]; then
+                    install_name_tool -change "$dep" "@rpath/$db" "$f" 2>/dev/null
+                fi
+                ;;
+        esac
+    done <<EOF
+$deps
+EOF
+}
 
+normalize() {
+    local app="$1" fw="$app/Contents/Frameworks" lib exe
     for lib in "$fw"/*.dylib; do
         [ -e "$lib" ] || continue
-        base="$(basename "$lib")"
-        chmod u+w "$lib"
-        install_name_tool -id "@rpath/$base" "$lib" 2>/dev/null || true
-        # Repoint the broken "@loader_path/../lib" rpath at the Frameworks dir
-        # the library now lives in.
-        while IFS= read -r rp; do
-            [ "$rp" = "@loader_path/../lib" ] &&
-                install_name_tool -rpath "@loader_path/../lib" "@loader_path" "$lib" 2>/dev/null || true
-        done < <(otool -l "$lib" | awk '/LC_RPATH/{f=1} f&&/ path /{print $2; f=0}')
-        # Repoint any Homebrew-absolute dependency that is now bundled.
-        while IFS= read -r dep; do
-            case "$dep" in
-                "$BREW_PREFIX"/*.dylib | /usr/local/*.dylib)
-                    db="$(basename "$dep")"
-                    [ -f "$fw/$db" ] &&
-                        install_name_tool -change "$dep" "@rpath/$db" "$lib" 2>/dev/null || true
-                    ;;
-            esac
-        done < <(deps_of "$lib")
+        normalize_one "$lib" "$fw" id
     done
-
-    # Fix the same Homebrew-absolute references in the Mach-O executables.
     for exe in "$app/Contents/MacOS/"*; do
         [ -f "$exe" ] || continue
         case "$(file -b "$exe" 2>/dev/null)" in *Mach-O*) ;; *) continue ;; esac
-        while IFS= read -r dep; do
-            case "$dep" in
-                "$BREW_PREFIX"/*.dylib | /usr/local/*.dylib)
-                    db="$(basename "$dep")"
-                    [ -f "$fw/$db" ] &&
-                        install_name_tool -change "$dep" "@rpath/$db" "$exe" 2>/dev/null || true
-                    ;;
-            esac
-        done < <(deps_of "$exe")
+        normalize_one "$exe" "$fw"
     done
-    return 0
 }
 
 # Phase 3: ad-hoc re-sign everything install_name_tool touched.
 resign() {
-    local app="$1"
-    find "$app" -name '*.dylib' -exec codesign --remove-signature {} + 2>/dev/null || true
-    find "$app" -name '*.dylib' -exec codesign --force --sign - {} + 2>/dev/null || true
-    local exe
+    local app="$1" f exe
+    while IFS= read -r f; do
+        [ -n "$f" ] && codesign --force --sign - "$f" 2>/dev/null
+    done <<EOF
+$(find "$app" -name '*.dylib')
+EOF
     for exe in "$app/Contents/MacOS/"*; do
         [ -f "$exe" ] || continue
-        case "$(file -b "$exe" 2>/dev/null)" in *Mach-O*) ;; *) continue ;; esac
-        codesign --force --sign - "$exe" 2>/dev/null || true
+        case "$(file -b "$exe" 2>/dev/null)" in *Mach-O*) codesign --force --sign - "$exe" 2>/dev/null ;; esac
     done
-    codesign --force --sign - "$app" 2>/dev/null || true
-    return 0
+    codesign --force --sign - "$app" 2>/dev/null
 }
 
-# Phase 4: fail if any @rpath/*.dylib dependency is still unresolved.
+# Phase 4: report any @rpath/*.dylib dependency still unresolved.
 verify() {
-    local app="$1"
-    local fw="$app/Contents/Frameworks"
-    local missing=0 lib dep db
+    local app="$1" fw="$app/Contents/Frameworks" missing=0 lib dep db deps
     for lib in "$fw"/*.dylib "$app/Contents/MacOS/"*; do
         [ -f "$lib" ] || continue
+        deps="$(deps_of "$lib")"
         while IFS= read -r dep; do
             case "$dep" in
                 @rpath/*.dylib)
                     db="${dep#@rpath/}"
-                    [ -f "$fw/$db" ] || {
+                    if [ ! -f "$fw/$db" ]; then
                         echo "    MISSING: $db (needed by $(basename "$lib"))" >&2
                         missing=1
-                    }
+                    fi
                     ;;
             esac
-        done < <(deps_of "$lib")
+        done <<EOF
+$deps
+EOF
     done
     return $missing
 }
 
-main() {
-    [ "$#" -ge 1 ] || { echo "usage: $0 App.app [App2.app ...]" >&2; exit 2; }
-    for app in "$@"; do
-        if [ ! -d "$app/Contents/Frameworks" ]; then
-            echo "==> $app: no Contents/Frameworks, skipping"
-            continue
-        fi
-        echo "==> Fixing $app"
-        copy_missing "$app/Contents/Frameworks"
-        normalize "$app"
-        resign "$app"
-        if verify "$app"; then
-            echo "    OK: all @rpath dependencies resolve inside the bundle"
-        else
-            echo "    FAILED: unresolved dependencies remain in $app" >&2
-            exit 1
-        fi
-    done
-}
-
-main "$@"
+rc=0
+[ "$#" -ge 1 ] || { echo "usage: $0 App.app [App2.app ...]" >&2; exit 2; }
+for app in "$@"; do
+    if [ ! -d "$app/Contents/Frameworks" ]; then
+        echo "==> $app: no Contents/Frameworks, skipping"
+        continue
+    fi
+    echo "==> Fixing $app"
+    copy_missing "$app/Contents/Frameworks"
+    normalize "$app"
+    resign "$app"
+    if verify "$app"; then
+        echo "    OK: all @rpath dependencies resolve inside the bundle"
+    else
+        echo "    FAILED: unresolved dependencies remain in $app" >&2
+        rc=1
+    fi
+done
+exit $rc

--- a/scripts/macos-fix-deps.sh
+++ b/scripts/macos-fix-deps.sh
@@ -55,10 +55,16 @@ deps_of() { otool -L "$1" 2>/dev/null | tail -n +2 | awk '{print $1}'; }
 
 # Locate a library by basename on the host. Echoes the path, or returns 1.
 find_host_lib() {
-    local name="$1" d
+    local name="$1" d hit
     for d in "${SEARCH_DIRS[@]}"; do
         [ -f "$d/$name" ] && { printf '%s\n' "$d/$name"; return 0; }
     done
+    # Fallback: some Homebrew libraries live in nested directories the flat
+    # opt/*/lib globs miss — notably gcc, which keeps libgcc_s / libgfortran
+    # under opt/gcc/lib/gcc/current. Search the real Cellar tree (no symlinks
+    # to chase) for the basename and take the first match.
+    hit="$(find "$BREW_PREFIX/Cellar" -name "$name" -type f 2>/dev/null | head -1)"
+    [ -n "$hit" ] && { printf '%s\n' "$hit"; return 0; }
     return 1
 }
 

--- a/scripts/macos-package.sh
+++ b/scripts/macos-package.sh
@@ -200,11 +200,28 @@ ARCH=$(uname -m)
 DMG="$BUILD_DIR/Blaze-${VERSION}-macOS-${ARCH}.dmg"
 
 echo "==> Creating $DMG..."
-hdiutil create \
-    -volname "Blaze" \
-    -srcfolder "$STAGING" \
-    -ov -format UDZO \
-    "$DMG" 2>&1 | grep -v "^Checksumming\|^  \|^verified\|^created:"
+# hdiutil create can fail with "Resource busy" while Spotlight/mds is still
+# indexing the freshly written staging tree; flush, detach any stale volume and
+# retry with backoff (same guard as the CI release workflow). Output goes to a
+# log so the retry can test hdiutil's own exit status (not a piped grep's).
+sync
+hdiutil detach /Volumes/Blaze -force 2>/dev/null || true
+created=false
+for i in 1 2 3 4 5; do
+    if hdiutil create -volname "Blaze" -srcfolder "$STAGING" -ov -format UDZO "$DMG" \
+        >"$BUILD_DIR/hdiutil-create.log" 2>&1; then
+        created=true
+        break
+    fi
+    echo "    hdiutil create failed (attempt $i), retrying in 10s..."
+    sleep 10
+done
+if [ "$created" != true ]; then
+    echo "Error: failed to create DMG after 5 attempts" >&2
+    cat "$BUILD_DIR/hdiutil-create.log" >&2
+    exit 1
+fi
+rm -f "$BUILD_DIR/hdiutil-create.log"
 
 rm -rf "$STAGING"
 echo ""

--- a/scripts/macos-package.sh
+++ b/scripts/macos-package.sh
@@ -150,68 +150,19 @@ for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
 done
 
 # ---------------------------------------------------------------------------
-# 6. Fix hardcoded Homebrew library paths
+# 6. Bundle transitive deps, normalize install names, and re-sign
 #
-# Some Homebrew dylibs embed their Cellar/opt install path as their own
-# LC_ID_DYLIB. macdeployqt copies them but doesn't update the ID, so dyld
-# can't match them when other libraries look them up by name. We rewrite each
-# ID to @rpath/<name> and fix every caller in the same bundle.
+# Delegate to the shared scripts/macos-fix-deps.sh (also used by the CI release
+# workflow) so there is a single source of truth: it pulls in any transitive
+# libraries macdeployqt missed, rewrites hardcoded Homebrew install names to
+# @rpath, and — crucially — ad-hoc re-signs every modified binary. Without the
+# re-sign the app seal is invalid and a downloaded copy is rejected by
+# Gatekeeper as "damaged".
 # ---------------------------------------------------------------------------
-echo "==> Fixing hardcoded Homebrew library IDs..."
-
-fix_abs_id() {
-    local APP="$1"
-    local FW="$APP/Contents/Frameworks"
-    local MACOS="$APP/Contents/MacOS"
-
-    [ -d "$FW" ] || return
-
-    # First pass: collect old→new pairs and fix each dylib's self-ID.
-    # Write to a temp file so the second pass can iterate without bash 4
-    # associative arrays (macOS ships bash 3.2).
-    local pairs
-    pairs=$(mktemp)
-    for lib in "$FW"/*.dylib; do
-        [ -f "$lib" ] || continue
-        local old_id
-        old_id=$(otool -D "$lib" 2>/dev/null | tail -1)
-        case "$old_id" in
-            /usr/local/*)
-                local libname new_id
-                libname=$(basename "$lib")
-                new_id="@rpath/$libname"
-                echo "$old_id|$new_id" >> "$pairs"
-                chmod 755 "$lib"
-                install_name_tool -id "$new_id" "$lib" 2>/dev/null || true
-                ;;
-        esac
-    done
-
-    local count
-    count=$(wc -l < "$pairs" | tr -d ' ')
-    if [ "$count" -eq 0 ]; then
-        rm "$pairs"
-        return
-    fi
-
-    # Second pass: fix every caller (main binary + all dylibs).
-    for f in "$MACOS"/* "$FW"/*.dylib; do
-        [ -f "$f" ] || continue
-        while IFS='|' read -r old new; do
-            if otool -L "$f" 2>/dev/null | grep -qF "$old"; then
-                chmod 755 "$f"
-                install_name_tool -change "$old" "$new" "$f" 2>/dev/null || true
-            fi
-        done < "$pairs"
-    done
-    rm "$pairs"
-
-    echo "    $(basename $APP): fixed $count hardcoded IDs"
-}
-
+echo "==> Bundling transitive deps + normalizing + re-signing..."
 for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
-    [ -d "$APP" ] || continue
-    fix_abs_id "$APP"
+    [ -d "$APP/Contents/Frameworks" ] || continue
+    scripts/macos-fix-deps.sh "$APP"
 done
 
 # ---------------------------------------------------------------------------

--- a/scripts/macos-package.sh
+++ b/scripts/macos-package.sh
@@ -73,6 +73,16 @@ cmake --install "$BUILD_DIR" --prefix "$STAGING" --config Release 2>&1 \
     | grep -v "^-- Install\|^-- Up-to-date"
 
 # ---------------------------------------------------------------------------
+# 3b. Bundle assets inside each .app (translocation-proof; see script header)
+# ---------------------------------------------------------------------------
+echo "==> Bundling assets inside .app bundles..."
+ASSET_APPS=()
+for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
+    [ -d "$APP" ] && ASSET_APPS+=("$APP")
+done
+scripts/macos-bundle-assets.sh "$STAGING/share/assets" "${ASSET_APPS[@]}"
+
+# ---------------------------------------------------------------------------
 # 4. Bundle Qt frameworks with macdeployqt
 #
 # Homebrew's macdeployqt can abort mid-process and DELETE the .app it was

--- a/scripts/macos-package.sh
+++ b/scripts/macos-package.sh
@@ -1,0 +1,235 @@
+#!/bin/bash
+# Build and package Blaze as a macOS DMG using the local Homebrew toolchain.
+#
+# Usage:
+#   ./scripts/macos-package.sh               # builds, packages, produces DMG
+#   ./scripts/macos-package.sh --skip-build  # skip cmake build (reuse macos-build/)
+#
+# Output: macos-build/Blaze-<version>-macOS-<arch>.dmg
+#
+# Prerequisites (install with ./scripts/install-macos-deps.sh):
+#   brew install cmake ninja ccache gdal opencv qt@6 libomp openblas lapack
+#
+# Note: this uses Homebrew's macdeployqt, which requires manual post-processing
+# to add the Qt platform plugins it misses (see step 5 below). The official CI
+# release uses the Qt installer's macdeployqt instead, which handles everything
+# automatically.
+
+set -e
+cd "$(dirname "$0")/.."
+
+# ---------------------------------------------------------------------------
+# 0. Parse arguments
+# ---------------------------------------------------------------------------
+SKIP_BUILD=false
+for arg in "$@"; do
+    case "$arg" in
+        --skip-build) SKIP_BUILD=true ;;
+        *) echo "Unknown argument: $arg"; exit 1 ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# 1. Build (unless --skip-build)
+# ---------------------------------------------------------------------------
+if [ "$SKIP_BUILD" = false ]; then
+    echo "==> Building..."
+    ./scripts/macos-build.sh
+fi
+
+BUILD_DIR="macos-build"
+if [ ! -d "$BUILD_DIR/Blaze.app" ]; then
+    echo "Error: $BUILD_DIR/Blaze.app not found. Run without --skip-build first."
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Resolve tool paths
+# ---------------------------------------------------------------------------
+QT_PREFIX=$(brew --prefix qtbase 2>/dev/null || brew --prefix qt@6 2>/dev/null || true)
+if [ -z "$QT_PREFIX" ]; then
+    echo "Error: Qt6 not found via Homebrew. Run ./scripts/install-macos-deps.sh"
+    exit 1
+fi
+
+MACDEPLOYQT="$QT_PREFIX/bin/macdeployqt"
+if [ ! -x "$MACDEPLOYQT" ]; then
+    echo "Error: macdeployqt not found at $MACDEPLOYQT"
+    exit 1
+fi
+
+QT_PLUGINS="$QT_PREFIX/share/qt/plugins"
+if [ ! -d "$QT_PLUGINS" ]; then
+    QT_PLUGINS="$QT_PREFIX/plugins"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Stage install
+# ---------------------------------------------------------------------------
+STAGING="$BUILD_DIR/_staging"
+rm -rf "$STAGING"
+echo "==> Staging install..."
+cmake --install "$BUILD_DIR" --prefix "$STAGING" --config Release 2>&1 \
+    | grep -v "^-- Install\|^-- Up-to-date"
+
+# ---------------------------------------------------------------------------
+# 4. Bundle Qt frameworks with macdeployqt
+#
+# Homebrew's macdeployqt can abort mid-process and DELETE the .app it was
+# working on (it encounters many install_name_tool errors due to Homebrew's
+# non-standard @executable_path rpaths and split-package layout). To protect
+# against this, we run macdeployqt on a temporary copy of each app and only
+# replace the staging app if bundling produced a valid Frameworks directory.
+# Verbose output goes to a log file to keep the terminal readable.
+# ---------------------------------------------------------------------------
+echo "==> Bundling Qt frameworks with macdeployqt..."
+
+run_macdeployqt() {
+    local APP="$1"
+    local name
+    name=$(basename "$APP")
+    local log="$BUILD_DIR/macdeployqt-$name.log"
+    local tmp="${APP}.deploytmp"
+
+    rm -rf "$tmp"
+    cp -r "$APP" "$tmp"
+
+    printf "    %-20s" "$name"
+    "$MACDEPLOYQT" "$tmp" -always-overwrite > "$log" 2>&1 || true
+
+    local fw_count=0
+    [ -d "$tmp/Contents/Frameworks" ] && \
+        fw_count=$(ls "$tmp/Contents/Frameworks/" 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$fw_count" -gt 5 ]; then
+        rm -rf "$APP"
+        mv "$tmp" "$APP"
+        echo "OK ($fw_count items bundled)"
+    else
+        rm -rf "$tmp"
+        echo "WARN: macdeployqt failed to bundle (check $log) — app will not run on other Macs"
+    fi
+}
+
+for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
+    [ -d "$APP" ] || continue
+    run_macdeployqt "$APP"
+done
+
+# ---------------------------------------------------------------------------
+# 5. Fix Qt plugins that Homebrew's macdeployqt misses
+#
+# macdeployqt only scans the keg it was installed from (qtbase) and misses
+# plugins that ship in other Homebrew kegs. Without platforms/libqcocoa.dylib
+# the app crashes immediately on launch ("Could not find the Qt platform
+# plugin cocoa").
+# ---------------------------------------------------------------------------
+echo "==> Adding missing Qt platform plugins..."
+QTSVG_PLUGINS="$(brew --prefix qtsvg 2>/dev/null)/share/qt/plugins"
+
+for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
+    [ -d "$APP/Contents/Frameworks" ] || continue
+    PLUGINS="$APP/Contents/PlugIns"
+
+    mkdir -p "$PLUGINS/platforms"
+    cp "$QT_PLUGINS/platforms/libqcocoa.dylib" "$PLUGINS/platforms/"
+    chmod 755 "$PLUGINS/platforms/libqcocoa.dylib"
+
+    mkdir -p "$PLUGINS/styles"
+    cp "$QT_PLUGINS/styles/libqmacstyle.dylib" "$PLUGINS/styles/"
+    chmod 755 "$PLUGINS/styles/libqmacstyle.dylib"
+
+    if [ -d "$QTSVG_PLUGINS/iconengines" ] && \
+       [ -d "$APP/Contents/Frameworks/QtSvg.framework" ]; then
+        mkdir -p "$PLUGINS/iconengines"
+        cp "$QTSVG_PLUGINS/iconengines/libqsvgicon.dylib" "$PLUGINS/iconengines/"
+        chmod 755 "$PLUGINS/iconengines/libqsvgicon.dylib"
+    fi
+
+    echo "    $(basename $APP): platforms styles $(ls $PLUGINS | grep -v 'platforms\|styles\|images\|platform' | tr '\n' ' ')"
+done
+
+# ---------------------------------------------------------------------------
+# 6. Fix hardcoded Homebrew library paths
+#
+# Some Homebrew dylibs embed their Cellar/opt install path as their own
+# LC_ID_DYLIB. macdeployqt copies them but doesn't update the ID, so dyld
+# can't match them when other libraries look them up by name. We rewrite each
+# ID to @rpath/<name> and fix every caller in the same bundle.
+# ---------------------------------------------------------------------------
+echo "==> Fixing hardcoded Homebrew library IDs..."
+
+fix_abs_id() {
+    local APP="$1"
+    local FW="$APP/Contents/Frameworks"
+    local MACOS="$APP/Contents/MacOS"
+
+    [ -d "$FW" ] || return
+
+    # First pass: collect old→new pairs and fix each dylib's self-ID.
+    # Write to a temp file so the second pass can iterate without bash 4
+    # associative arrays (macOS ships bash 3.2).
+    local pairs
+    pairs=$(mktemp)
+    for lib in "$FW"/*.dylib; do
+        [ -f "$lib" ] || continue
+        local old_id
+        old_id=$(otool -D "$lib" 2>/dev/null | tail -1)
+        case "$old_id" in
+            /usr/local/*)
+                local libname new_id
+                libname=$(basename "$lib")
+                new_id="@rpath/$libname"
+                echo "$old_id|$new_id" >> "$pairs"
+                chmod 755 "$lib"
+                install_name_tool -id "$new_id" "$lib" 2>/dev/null || true
+                ;;
+        esac
+    done
+
+    local count
+    count=$(wc -l < "$pairs" | tr -d ' ')
+    if [ "$count" -eq 0 ]; then
+        rm "$pairs"
+        return
+    fi
+
+    # Second pass: fix every caller (main binary + all dylibs).
+    for f in "$MACOS"/* "$FW"/*.dylib; do
+        [ -f "$f" ] || continue
+        while IFS='|' read -r old new; do
+            if otool -L "$f" 2>/dev/null | grep -qF "$old"; then
+                chmod 755 "$f"
+                install_name_tool -change "$old" "$new" "$f" 2>/dev/null || true
+            fi
+        done < "$pairs"
+    done
+    rm "$pairs"
+
+    echo "    $(basename $APP): fixed $count hardcoded IDs"
+}
+
+for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
+    [ -d "$APP" ] || continue
+    fix_abs_id "$APP"
+done
+
+# ---------------------------------------------------------------------------
+# 7. Package as DMG
+# ---------------------------------------------------------------------------
+VERSION=$(cmake -L -N "$BUILD_DIR" 2>/dev/null \
+    | grep "CMAKE_PROJECT_VERSION" | head -1 | cut -d= -f2 || true)
+[ -z "$VERSION" ] && VERSION="dev"
+ARCH=$(uname -m)
+DMG="$BUILD_DIR/Blaze-${VERSION}-macOS-${ARCH}.dmg"
+
+echo "==> Creating $DMG..."
+hdiutil create \
+    -volname "Blaze" \
+    -srcfolder "$STAGING" \
+    -ov -format UDZO \
+    "$DMG" 2>&1 | grep -v "^Checksumming\|^  \|^verified\|^created:"
+
+rm -rf "$STAGING"
+echo ""
+echo "Done: $DMG ($(du -sh "$DMG" | cut -f1))"

--- a/scripts/macos-package.sh
+++ b/scripts/macos-package.sh
@@ -166,6 +166,21 @@ for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
 done
 
 # ---------------------------------------------------------------------------
+# 6b. Verify each bundle is self-contained and validly signed
+#
+# Hard gate before we ship: macos-verify-bundle.sh fails if any bundle still
+# references a host-only library (Homebrew/Qt/Cellar) or has an invalid code
+# seal — i.e. anything that would crash or show "damaged" on a clean Mac. This
+# is the same check the CI release workflow runs.
+# ---------------------------------------------------------------------------
+echo "==> Verifying bundles are self-contained + validly signed..."
+VERIFY_APPS=()
+for APP in "$STAGING"/Blaze.app "$STAGING"/Blaze3D.app; do
+    [ -d "$APP/Contents/Frameworks" ] && VERIFY_APPS+=("$APP")
+done
+scripts/macos-verify-bundle.sh "${VERIFY_APPS[@]}"
+
+# ---------------------------------------------------------------------------
 # 7. Package as DMG
 # ---------------------------------------------------------------------------
 VERSION=$(cmake -L -N "$BUILD_DIR" 2>/dev/null \

--- a/scripts/macos-verify-bundle.sh
+++ b/scripts/macos-verify-bundle.sh
@@ -109,5 +109,16 @@ for app in "$@"; do
         rc=1
     fi
     rm -f /tmp/codesign-verify.$$
+
+    # Assets must be bundled at Contents/share/assets — get_asset_dir() checks
+    # this path first, and it is the only one that survives App Translocation.
+    # Missing it means the GUI aborts on launch from a downloaded DMG.
+    if [ -n "$(find "$app/Contents/share/assets" -type f 2>/dev/null | head -1)" ]; then
+        echo "    assets OK: bundled at Contents/share/assets"
+    else
+        echo "    assets FAILED: Contents/share/assets missing or empty — GUI will" >&2
+        echo "                  abort on launch under Gatekeeper App Translocation" >&2
+        rc=1
+    fi
 done
 exit $rc

--- a/scripts/macos-verify-bundle.sh
+++ b/scripts/macos-verify-bundle.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Verify a macOS .app bundle is self-contained AND validly signed, so it will
+# run on a clean Mac — one with no Homebrew, no Qt, no developer tooling.
+#
+# Why this exists:
+#   CI runners and dev machines already have Qt/GDAL/Homebrew installed, so a
+#   half-bundled app can silently fall back to those system copies and appear to
+#   work, then crash for a user who has none of them. And an app whose code seal
+#   was invalidated by install_name_tool (e.g. a framework modified after it was
+#   signed) is reported by Gatekeeper as "damaged and can't be opened". Neither
+#   failure is caught by running blaze-cli. This script is the gate that makes
+#   "green in CI" actually mean "runs on a clean Mac". Run it AFTER
+#   macos-fix-deps.sh, before building the DMG.
+#
+# It hard-fails (exit 1) if either check fails, for any .app passed:
+#
+#   1. Dependency closure — every dependency of every Mach-O in the bundle must
+#      resolve to one of:
+#        * something inside the bundle (an @rpath/@loader_path/@executable_path
+#          reference whose basename is present in the bundle), or
+#        * /usr/lib/** or /System/Library/** (the only library dirs guaranteed
+#          to exist on stock macOS).
+#      Any absolute reference into /opt/homebrew, /usr/local, a Qt install dir,
+#      the Cellar, a user home, etc. — or an @rpath lib that isn't bundled —
+#      is a guaranteed crash on a clean machine and fails the check.
+#
+#   2. Signature — `codesign --verify --deep --strict` must pass.
+#
+# Usage: scripts/macos-verify-bundle.sh path/to/Foo.app [path/to/Bar.app ...]
+
+set -u
+
+# Every Mach-O binary in the bundle: loose dylibs, plugins, framework binaries
+# (which have no .dylib extension), and the executables in Contents/MacOS.
+list_macho() {
+    local app="$1" fw name exe
+    find "$app" -name '*.dylib' 2>/dev/null
+    for fw in "$app"/Contents/Frameworks/*.framework; do
+        [ -d "$fw" ] || continue
+        name="$(basename "$fw" .framework)"
+        [ -e "$fw/$name" ] && printf '%s\n' "$fw/$name"
+    done
+    for exe in "$app/Contents/MacOS/"*; do
+        [ -f "$exe" ] && printf '%s\n' "$exe"
+    done
+}
+
+check_closure() {
+    local app="$1" bad=0 file dep base macho index
+    macho="$(list_macho "$app")"
+    # Precompute the set of file basenames present anywhere in the bundle, so a
+    # bundle-relative dependency (@rpath/@loader_path/@executable_path) can be
+    # resolved by a fast membership test instead of a find-per-dependency.
+    index="$(find "$app" 2>/dev/null | sed 's#.*/##' | sort -u)"
+    while IFS= read -r file; do
+        [ -n "$file" ] || continue
+        # tail -n +2 drops the otool header line; for a dylib the next line is
+        # its own id, which we tolerate (self-reference is harmless).
+        while IFS= read -r dep; do
+            dep="${dep%% (*}"            # strip " (compatibility version ...)"
+            dep="${dep#"${dep%%[![:space:]]*}"}"  # ltrim
+            [ -n "$dep" ] || continue
+            case "$dep" in
+                /usr/lib/*|/System/Library/*) ;;                  # stock macOS — OK
+                @executable_path/*|@loader_path/*|@rpath/*)
+                    base="${dep##*/}"
+                    if ! printf '%s\n' "$index" | grep -qxF "$base"; then
+                        echo "    UNRESOLVED: $dep (needed by ${file#"$app"/})" >&2
+                        bad=1
+                    fi
+                    ;;
+                /*)
+                    # Any other absolute path = host-specific, won't exist on a
+                    # clean Mac (Homebrew, Qt install dir, Cellar, /Users/...).
+                    echo "    NON-PORTABLE: $dep (needed by ${file#"$app"/})" >&2
+                    bad=1
+                    ;;
+            esac
+        done <<INNER
+$(otool -L "$file" 2>/dev/null | tail -n +2 | awk '{print $1}')
+INNER
+    done <<OUTER
+$macho
+OUTER
+    return $bad
+}
+
+rc=0
+[ "$#" -ge 1 ] || { echo "usage: $0 App.app [App2.app ...]" >&2; exit 2; }
+for app in "$@"; do
+    if [ ! -d "$app" ]; then
+        echo "==> $app: not found, skipping" >&2
+        rc=1; continue
+    fi
+    echo "==> Verifying $app"
+
+    if check_closure "$app"; then
+        echo "    closure OK: all dependencies are in-bundle or stock macOS"
+    else
+        echo "    closure FAILED: bundle is not self-contained (see above)" >&2
+        rc=1
+    fi
+
+    if codesign --verify --deep --strict --verbose=2 "$app" >/tmp/codesign-verify.$$ 2>&1; then
+        echo "    signature OK: valid on disk, satisfies Designated Requirement"
+    else
+        echo "    signature FAILED: Gatekeeper would reject this as damaged" >&2
+        tail -3 /tmp/codesign-verify.$$ >&2
+        rc=1
+    fi
+    rm -f /tmp/codesign-verify.$$
+done
+exit $rc

--- a/src/blaze.cpp
+++ b/src/blaze.cpp
@@ -13,8 +13,9 @@ static bool is_las_file(const fs::path& p) {
 
 int main([[maybe_unused]] int argc, char* argv[]) {
   try {
-    fs::path config_path = AssetRetriever::get_asset("default_config.json");
+    fs::path config_path;
     std::vector<fs::path> las_files;
+    bool use_default_config = true;
 
     if (argc == 2 && is_las_file(argv[1])) {
       // Single-file mode: blaze-cli file.laz
@@ -22,13 +23,17 @@ int main([[maybe_unused]] int argc, char* argv[]) {
     } else {
       if (argc > 1) {
         config_path = argv[1];
+        use_default_config = false;
       }
       if (argc > 2) {
         las_files.push_back(argv[2]);
       }
     }
 
-    Config config = Config::FromFile(config_path);
+    // Use Config::Default() when no explicit config is given so the output
+    // directory resolves to a writable location even when the default config
+    // lives inside a read-only bundle or mounted DMG.
+    Config config = use_default_config ? Config::Default() : Config::FromFile(config_path);
     std::cout << config << std::endl;
 
     if (las_files.empty() && config.las_files.size() == 0) {

--- a/src/lib/config_input/config_input.hpp
+++ b/src/lib/config_input/config_input.hpp
@@ -290,7 +290,16 @@ struct Config {
 
   void write_to_file(const fs::path& filename) const;
 
-  static Config Default() { return FromFile(AssetRetriever::get_asset("default_config.json")); }
+  static Config Default() {
+    Config c = FromFile(AssetRetriever::get_asset("default_config.json"));
+    // The asset directory may be read-only (e.g. inside a mounted DMG or an
+    // installed .app bundle). Redirect any relative output path to a writable
+    // per-user data directory so the first run doesn't hit a read-only error.
+    if (!c.output_directory.is_absolute()) {
+      c.output_directory = LocalDataRetriever::get_local_data(c.output_directory);
+    }
+    return c;
+  }
 
   Config& operator=(const Config& config) = default;
   Config(const Config& config) = delete;

--- a/src/lib/utilities/resources.cpp
+++ b/src/lib/utilities/resources.cpp
@@ -46,11 +46,19 @@ fs::path get_asset_dir() {
   }
   fs::path path(buffer);
 #endif
+  // First candidate, "<exe>/../../share/assets": on Linux/Windows the installed
+  // <prefix>/share/assets; on a macOS .app it resolves to
+  // MyApp.app/Contents/share/assets. The macOS packaging deliberately copies the
+  // assets THERE (scripts/macos-bundle-assets.sh) so the app is self-contained:
+  // a downloaded app runs under Gatekeeper App Translocation from a random temp
+  // dir with NO sibling share/, and only this in-bundle path survives. Do not
+  // remove it as "dead Linux code" — it is what keeps the GUI from aborting at
+  // launch on a clean Mac.
   std::vector<fs::path> asset_paths = {path.parent_path().parent_path() / "share" / "assets"};
 #ifdef __APPLE__
-  // For .app bundles the executable lives at MyApp.app/Contents/MacOS/<exe>.
-  // Assets installed next to the bundle sit at <prefix>/share/assets, which is
-  // four directory levels above the executable.
+  // Fallback for a non-translocated launch straight from the DMG/install tree:
+  // assets sitting next to the bundle at <prefix>/share/assets, four directory
+  // levels above the executable (MyApp.app/Contents/MacOS/<exe>).
   asset_paths.push_back(path.parent_path().parent_path().parent_path().parent_path() / "share" /
                         "assets");
 #endif


### PR DESCRIPTION
Blaze.app & Blaze3D.app are both working from within the dmgs that get created with the Release Application github workflow, on both my x86 mac & my colleague's arm64 mac.
(Release #7 in this fork: https://github.com/ChristopherBradley/Blaze/actions/runs/26860868104)

Kind of a ridiculous amount of extra code to get this working, and I haven't really looked into how it works, very much vibe-coded.